### PR TITLE
fix End and NoEnd terminal parsers

### DIFF
--- a/terminals.go
+++ b/terminals.go
@@ -122,14 +122,26 @@ func OrdTokens(patterns []string, names []string) Parser {
 }
 
 // End is a parser function to detect end of scanner output.
-func End(s Scanner) (ParsecNode, Scanner) {
-	return s.Endof(), s
+func End() Parser {
+	return func(s Scanner) (ParsecNode, Scanner) {
+		if s.Endof() {
+			return true, s
+		} else {
+			return nil, s
+		}
+	}
 }
 
 // NoEnd is a parser function to detect not-an-end of
 // scanner output.
-func NoEnd(s Scanner) (ParsecNode, Scanner) {
-	return !s.Endof(), s
+func NoEnd() Parser {
+	return func(s Scanner) (ParsecNode, Scanner) {
+		if !s.Endof() {
+			return true, s
+		} else {
+			return nil, s
+		}
+	}
 }
 
 var escapeCode = [256]byte{ // TODO: size can be optimized

--- a/terminals_test.go
+++ b/terminals_test.go
@@ -1,0 +1,39 @@
+package parsec
+
+import "testing"
+
+func TestEnd(t *testing.T) {
+	p := And(nil, Token("test", "T"), End())
+	s := NewScanner([]byte("test"))
+	v, e := p(s)
+	if v == nil {
+		t.Errorf("End() didn't match %q", e)
+	}
+}
+
+func TestNotEnd(t *testing.T) {
+	p := And(nil, Token("test", "T"), End())
+	s := NewScanner([]byte("testing"))
+	v, _ := p(s)
+	if v != nil {
+		t.Errorf("End() shouldn't have matched %q", v)
+	}
+}
+
+func TestNoEnd(t *testing.T) {
+	p := And(nil, Token("test", "T"), NoEnd())
+	s := NewScanner([]byte("testing"))
+	v, e := p(s)
+	if v == nil {
+		t.Errorf("NoEnd() didn't match %q", e)
+	}
+}
+
+func TestNotNoEnd(t *testing.T) {
+	p := And(nil, Token("test", "T"), NoEnd())
+	s := NewScanner([]byte("test"))
+	v, _ := p(s)
+	if v != nil {
+		t.Errorf("NoEnd() shouldn't have matched %q", v)
+	}
+}


### PR DESCRIPTION
As originally written these functions don't return Parser functions like the
rest of the functions in terminals.go and aren't usable.

Change so they return Parser functions that detect the End of the Scanner.

Add some tests to ensure they work as expected.