### PR TITLE
Add SetWSPattern method for SimpleScanner

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -50,6 +50,7 @@ type SimpleScanner struct {
 	buf          []byte // input buffer
 	cursor       int    // cursor within input buffer
 	patternCache map[string]*regexp.Regexp
+	wsPattern    string // white space pattern used by SkipWS()
 }
 
 // NewScanner creates and returns a reference to new instance
@@ -59,6 +60,7 @@ func NewScanner(text []byte) Scanner {
 		buf:          text,
 		cursor:       0,
 		patternCache: make(map[string]*regexp.Regexp),
+		wsPattern:    `^[ \t\r\n]+`,
 	}
 }
 
@@ -68,6 +70,7 @@ func (s *SimpleScanner) Clone() Scanner {
 		buf:          s.buf,
 		cursor:       s.cursor,
 		patternCache: s.patternCache,
+		wsPattern:    s.wsPattern,
 	}
 }
 
@@ -122,7 +125,7 @@ func (s *SimpleScanner) SubmatchAll(
 
 // SkipWS method receiver in Scanner{} interface.
 func (s *SimpleScanner) SkipWS() ([]byte, Scanner) {
-	return s.SkipAny(`^[ \t\r\n]+`)
+	return s.SkipAny(s.wsPattern)
 }
 
 // SkipAny method receiver in Scanner{} interface.
@@ -136,6 +139,10 @@ func (s *SimpleScanner) SkipAny(pattern string) ([]byte, Scanner) {
 // Endof method receiver in Scanner{} interface.
 func (s *SimpleScanner) Endof() bool {
 	return s.cursor >= len(s.buf)
+}
+
+func (s *SimpleScanner) SetWSPattern(pattern string) {
+	s.wsPattern = pattern
 }
 
 //---- local methods

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -127,6 +127,21 @@ func TestEndof(t *testing.T) {
 	}
 }
 
+func TestSetWSPattern(t *testing.T) {
+	text := []byte(`// comment`)
+	ref := `// comment`
+	s := NewScanner(text)
+	s.(*SimpleScanner).SetWSPattern(`^//.*`)
+	m, s := s.SkipWS()
+	if string(m) != ref {
+		t.Fatalf("mismatch expected %q, got %q", ref, string(m))
+	}
+	expcur := 10
+	if s.GetCursor() != expcur {
+		t.Fatalf("expected cursor position %v, got %v", expcur, s.GetCursor())
+	}
+}
+
 func BenchmarkSScanClone(b *testing.B) {
 	text := []byte("hello world")
 	s := NewScanner(text)


### PR DESCRIPTION
I removed the other pull request which unnecessarily changed the Scanner interface. This just adds a method for SimpleScanner since it is just an implementation detail.

Adds method for #24 